### PR TITLE
Code review: fix edge cases in tweak function and constraint validation

### DIFF
--- a/lab1CI.ipynb
+++ b/lab1CI.ipynb
@@ -18,7 +18,7 @@
     "):\n",
     "    NUM_ITEMS = len(VALUES)\n",
     "    NUM_KNAPSACKS = len(CONSTRAINTS)\n",
-    "    NUM_DIMENSIONS = WEIGHTS.shape[1]\n",
+    "    # NUM_DIMENSIONS = WEIGHTS.shape[1] \n",
     "\n",
     "    # Soluzione iniziale basata su valore/peso\n",
     "    def generate_valid_initial_solution():\n",
@@ -55,9 +55,10 @@
     "            k = solution[i]\n",
     "            if k >= 0:\n",
     "                usage[k] += WEIGHTS[i]\n",
-    "        overuse = np.maximum(usage - CONSTRAINTS, 0)\n",
-    "        penalty = np.sum(overuse)\n",
-    "        return total_value(solution) - penalty * 10\n",
+    "        # hard constraint to avoid accepting invalid solutions\n",
+    "        if np.any(usage > CONSTRAINTS):\n",
+    "            return -1e12\n",
+    "        return total_value(solution)\n",
     "\n",
     "    # Tweak intelligente: sposta solo se non viola\n",
     "    def tweak(solution):\n",
@@ -77,7 +78,10 @@
     "            np.random.shuffle(candidate_knapsacks)\n",
     "            for new_k in candidate_knapsacks:\n",
     "                if np.all(usage[new_k] + WEIGHTS[i] <= CONSTRAINTS[new_k]):\n",
-    "                    usage[original_k] -= WEIGHTS[i]\n",
+    "                    # check if item was already assigned before removing it\n",
+    "                    # otherwise usage[-1] would modify the last knapsack by mistake\n",
+    "                    if original_k >= 0:\n",
+    "                        usage[original_k] -= WEIGHTS[i]\n",
     "                    usage[new_k] += WEIGHTS[i]\n",
     "                    new_solution[i] = new_k\n",
     "                    break\n",
@@ -102,16 +106,39 @@
     "            if new_cost > best_cost:\n",
     "                best_solution = deepcopy(new_solution)\n",
     "                best_cost = new_cost\n",
-    "\n",
+    "    print(is_valid(best_solution))\n",
     "    return best_solution, best_cost\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 106,
    "id": "5fe1c536",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 10000/10000 [00:02<00:00, 3993.90it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "TC1 Value: 1065\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# TC1\n",
     "# Problem 1:\n",
@@ -128,6 +155,40 @@
     "sol1, val1 = simulated_annealing_knapsack(VALUES, WEIGHTS, CONSTRAINTS)\n",
     "print(\"TC1 Value:\", val1)\n",
     "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "id": "dcf52783",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 10000/10000 [00:15<00:00, 628.09it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "TC2 Value: 46622\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
     "# TC2\n",
     "rng = np.random.default_rng(seed=42)\n",
     "NUM_KNAPSACKS = 10\n",
@@ -137,9 +198,40 @@
     "WEIGHTS = rng.integers(0, 1000, size=(NUM_ITEMS, NUM_DIMENSIONS))\n",
     "CONSTRAINTS = rng.integers(2000, 1000 * NUM_ITEMS // NUM_KNAPSACKS, size=(NUM_KNAPSACKS, NUM_DIMENSIONS))\n",
     "\n",
-    "sol2, val2 = simulated_annealing_knapsack(VALUES, WEIGHTS, CONSTRAINTS, max_steps=2000, temp_init=200, tweak_strength=0.2)\n",
-    "print(\"TC2 Value:\", val2)\n",
-    "\n",
+    "sol2, val2 = simulated_annealing_knapsack(VALUES, WEIGHTS, CONSTRAINTS, max_steps=10000, temp_init=200, tweak_strength=0.2)\n",
+    "print(\"TC2 Value:\", val2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f658fdff",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 50/50 [00:19<00:00,  2.59it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "TC3 Value: 1888203\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
     "# TC3\n",
     "rng = np.random.default_rng(seed=42)\n",
     "NUM_KNAPSACKS = 100\n",
@@ -149,20 +241,14 @@
     "WEIGHTS = rng.integers(0, 1000, size=(NUM_ITEMS, NUM_DIMENSIONS))\n",
     "CONSTRAINTS = rng.integers(10000, 2000 * NUM_ITEMS // NUM_KNAPSACKS, size=(NUM_KNAPSACKS, NUM_DIMENSIONS))\n",
     "\n",
-    "sol3, val3 = simulated_annealing_knapsack(VALUES, WEIGHTS, CONSTRAINTS, max_steps=3000, temp_init=500, tweak_strength=0.1)\n",
+    "sol3, val3 = simulated_annealing_knapsack(VALUES, WEIGHTS, CONSTRAINTS, max_steps=, temp_init=500, tweak_strength=0.1)\n",
     "print(\"TC3 Value:\", val3)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "873ff6af",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -176,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The code is well-structured and works correctly for the most part. The simulated annealing approach is implemented properly and the greedy initialization is a great idea since it starts from a good solution. Validation and fitness functions are correct: `is_valid()` function properly compute the usage for each knapsack and verifies all dimensional contraint with `np.all(usage <= CONSTRAINTS)`, while `total_value()` correctly sums values only for assigned items (where `solution[i] >= 0`). The greedy initialization is composed by two steps:

- calculates value density (`VALUES / sum(WEIGHTS)`) to prioritize efficient items
- sorts items by this ratio and assigns greedily, which typically gives almost an optimal solutions already

The tweak function attempts to move items between knapsacks while maintaining feasibility by checking constraints before accepting moves. Checking the solution, I found two minor issues that can sometimes lead to an invalid solution. Those are the following:

### Problem in tweak function
In the following segment:
```python
    for new_k in candidate_knapsacks:
        if np.all(usage[new_k] + WEIGHTS[i] <= CONSTRAINTS[new_k]):
            usage[original_k] -= WEIGHTS[i]
            usage[new_k] += WEIGHTS[i]
            new_solution[i] = new_k
            break
```
There is a risk where if an item is not assigned (original_k == -1), doing `usage[original_k] -= WEIGHTS[i]` actually does `usage[-1]` which modifies the last knapsack by mistake. This problem is fixed by adding:

```python
if original_k >= 0:
    usage[original_k] -= WEIGHTS[i]
```

### Penalty too weak
The penalty of `* 10` might accept solutions that violate constraints if the value is high enough. This was changed to hard constraint that rejects any invalid solution:
```python
if np.any(usage > CONSTRAINTS):
    return -1e12
```

These bugs are pretty rare, they mostly happen by chance,  especially in TC3 with many items. The greedy initialization usually assigns most items correctly so the tweak bug doesn't show up often. Still worth fixing though.

Overall the implementation is good, just needed these small corrections for edge cases.
